### PR TITLE
Base url

### DIFF
--- a/templates/connect.html
+++ b/templates/connect.html
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='dist/css/sb-admin-2.css') }}">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='dist/css/timeline.css') }}">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='bower_components/bootstrap/dist/css/bootstrap.min.css') }}">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='bower_components/metisMenu/dist/metisMenu.min.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('zookeeper_browser.static', filename='dist/css/sb-admin-2.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('zookeeper_browser.static', filename='dist/css/timeline.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('zookeeper_browser.static', filename='bower_components/bootstrap/dist/css/bootstrap.min.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('zookeeper_browser.static', filename='bower_components/metisMenu/dist/metisMenu.min.css') }}">
     <title>Title</title>
 </head>
 <body>

--- a/templates/connect.html
+++ b/templates/connect.html
@@ -24,7 +24,7 @@
 
         <div class="col-lg-2"></div>
         <div class="col-lg-8">
-            <form action="{{ url_for('connect') }}" method=post>
+            <form action="{{ url_for('zookeeper_browser.connect') }}" method=post>
                 <div class="form-group">
 
                     <label for="inputConStr">Input connection string</label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
 </head>
 <body>
 <div id="wrapper">
-    <form action="{{ url_for('index', path=path) }}" id="frmId" method=post>
+    <form action="{{ url_for('zookeeper_browser.index', path=path) }}" id="frmId" method=post>
         <nav class="navbar navbar-default navbar-static-top" role="navigation">
             <div class="navbar-header">
                 <a class="navbar-brand" href="/">Zookeeper browser</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,10 +2,10 @@
 <html lang="en" xmlns="http://www.w3.org/1999/html">
 <head>
     <meta charset="UTF-8">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='dist/css/sb-admin-2.css') }}">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='dist/css/timeline.css') }}">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='bower_components/bootstrap/dist/css/bootstrap.min.css') }}">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='bower_components/metisMenu/dist/metisMenu.min.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('zookeeper_browser.static', filename='dist/css/sb-admin-2.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('zookeeper_browser.static', filename='dist/css/timeline.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('zookeeper_browser.static', filename='bower_components/bootstrap/dist/css/bootstrap.min.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('zookeeper_browser.static', filename='bower_components/metisMenu/dist/metisMenu.min.css') }}">
     <title>Zookeeper browser by Mijalko</title>
     <script>
         function OnDelClickHandler() {

--- a/zkbrowser.py
+++ b/zkbrowser.py
@@ -8,6 +8,7 @@ from flask import Blueprint
 import collections
 import datetime
 import sys
+import os
 
 from kazoo.client import KazooClient
 
@@ -129,7 +130,7 @@ def connect():
 
 if __name__ == '__main__':
     #app.debug = True
-    prefix = "/"
+    prefix = os.environ.get("BASE_URL", "/")
     if len(sys.argv) > 1:
 	    prefix=sys.argv[1]
 

--- a/zkbrowser.py
+++ b/zkbrowser.py
@@ -15,7 +15,7 @@ app = Flask(__name__)
 app.secret_key = 'my secret key'
 app.config['SESSION_TYPE'] = 'filesystem'
 
-bp = Blueprint('zookeeper_browser', __name__, template_folder="templates")
+bp = Blueprint('zookeeper_browser', __name__, template_folder="templates", static_folder="static")
 
 
 


### PR DESCRIPTION
I need to run the zookeeper_browser behind a reverse proxy which rotues by prefixes, so I added a rudimentary support for that.  By default the zookeeper_browser works as it does, but you can specify a base_url prefix, either by a parameter to the command, or by the BASE_URL environment variable.

I have this running under Marathon/Mesos, using traefik as the reverse proxy, and it works well here.

I have not done much web development in python, I hope I used a 'sane' way of doing it.