### PR TITLE
Adding support for deafult ZK server based on environment variable

### DIFF
--- a/templates/connect.html
+++ b/templates/connect.html
@@ -28,7 +28,7 @@
                 <div class="form-group">
 
                     <label for="inputConStr">Input connection string</label>
-                    <input type="text" class="form-control" id="inputConStr" placeholder="127.0.0.1:2181" name="inputConStr">
+		    <input type="text" class="form-control" id="inputConStr" placeholder="{{ defaultZK }}" name="inputConStr">
 
                 </div>
                 <button type="submit" class="btn btn-default">Connect</button>

--- a/zkbrowser.py
+++ b/zkbrowser.py
@@ -12,6 +12,7 @@ from kazoo.client import KazooClient
 app = Flask(__name__)
 app.secret_key = 'my secret key'
 app.config['SESSION_TYPE'] = 'filesystem'
+defaultZK = os.environ.get("ZOOKEEPER_SERVERS", "127.0.0.1:2181")
 
 
 @app.route('/', methods=["GET", "POST"])
@@ -100,8 +101,8 @@ def connect():
     connection_string = None
     if request.method == 'POST':
         connection_string = request.form.get('inputConStr', None)
-        if connection_string is None:
-            connection_string = "127.0.0.1:2181"
+        if connection_string is None or len(connection_string) < 1:
+            connection_string = defaultZK
 
     if connection_string is not None:
         # try to connect
@@ -120,7 +121,7 @@ def connect():
             # redirect to index
             return redirect(url_for('index'))
 
-    return render_template('connect.html', connection_error=connection_error)
+    return render_template('connect.html', connection_error=connection_error, defaultZK=defaultZK)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I wanted to simplify the login process for my users, so I added a ZOOKEEPER_SERVERS environment variables which gets used as the default ZK server, instead of 127.0.0.1:2181.

As before, I have this working under Marathon/Mesos at my location.